### PR TITLE
Fix/afc 22/make restartable

### DIFF
--- a/src/log.erl
+++ b/src/log.erl
@@ -214,8 +214,7 @@ load() ->
         case get_env_bool(console) of
             true ->
                 ConsoleFmtConfig = log_plain:formatter_config(),
-                ok = logger:update_formatter_config(default, ConsoleFmtConfig),
-                ok;
+                ok = logger:update_formatter_config(default, ConsoleFmtConfig);
             false ->
                 case logger:remove_handler(default) of
                     ok -> ok;

--- a/src/log.erl
+++ b/src/log.erl
@@ -190,10 +190,8 @@ load() ->
     FormatterMod = formatter_module(Formatter),
     FileFmtConfig = FormatterMod:formatter_config(),
     %% We always log plain text in console backend
-    ConsoleFmtConfig = log_plain:formatter_config(),
     try
         ok = logger:set_primary_config(level, Level),
-        ok = logger:update_formatter_config(default, ConsoleFmtConfig),
         case logger:add_primary_filter(progress_report,
                                        {fun ?MODULE:progress_filter/2, stop}) of
             ok -> ok;
@@ -214,7 +212,10 @@ load() ->
             {error, {already_exist, _}} -> ok
         end,
         case get_env_bool(console) of
-            true -> ok;
+            true ->
+                ConsoleFmtConfig = log_plain:formatter_config(),
+                ok = logger:update_formatter_config(default, ConsoleFmtConfig),
+                ok;
             false ->
                 case logger:remove_handler(default) of
                     ok -> ok;


### PR DESCRIPTION
Currently `log:load/0` function unconditionally updates `default` logger handler and then if `console` variable in env is not `true` - deletes it. When `log` application is restarted without restarting kernel - it crashes on update because it previously deleted it. 
This PR makes `log:load/0` function update `default` logger handler only when console is present.