### PR TITLE
Fix/bp 112/gun filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ A wrapper around Erlang system logger to simply configuration.
 * `exclude_meta`: only makes sense when `formatter` is set to `json`. In this case keys listed in
   this option are excluded from resulting `meta` field of the logged JSON message. The default is
   `[domain, report_cb, gl, error_logger, logger_formatter]`.
+* `print_gun_shutdown_errors`: enables logging gun `noproc` and `{shutdown, normal}` error reports
+  in `shutdown_error` context from gun supervisor. Such reports occur when calling process finishes
+  earlier than gun's connection process. This situation does not affect application therefore such
+  reports are supressed by default. `true` enables logging of these reports. Default is `false`.
 
 ## Configuration example
 

--- a/src/log.erl
+++ b/src/log.erl
@@ -211,6 +211,15 @@ load() ->
             ok -> ok;
             {error, {already_exist, _}} -> ok
         end,
+        case logger:add_handler_filter(all_log, gun_error_filter, {fun log_gun:filter_supervisor_reports/2, #{}}) of
+            ok -> ok;
+            {error, {already_exist, _}} -> ok
+        end,
+        case logger:add_handler_filter(error_log, gun_error_filter, {fun log_gun:filter_supervisor_reports/2, #{}}) of
+            ok -> ok;
+            {error, {already_exist, _}} -> ok
+        end,
+
         case get_env_bool(console) of
             true ->
                 ConsoleFmtConfig = log_plain:formatter_config(),

--- a/src/log.erl
+++ b/src/log.erl
@@ -50,7 +50,7 @@
 -type option() :: level | rotate_size | rotate_count | single_line |
                   max_line_size | filesync_repeat_interval | dir |
                   sync_mode_qlen | drop_mode_qlen | flush_qlen | console |
-                  formatter | exclude_meta.
+                  formatter | exclude_meta | print_gun_shutdown_errors.
 
 -type meta_key() :: atom().
 -type meta_value() :: atom() | binary() | string() | number() |

--- a/src/log.erl
+++ b/src/log.erl
@@ -183,7 +183,6 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 load() ->
     Dir = get_env_non_empty_string(dir),
-    DisableGunFilters = get_env_disable_gun_filters(),
     AllLog = filename:join(Dir, "all.log"),
     ErrorLog = filename:join(Dir, "error.log"),
     Level = get_level_from_env(),

--- a/src/log_gun.erl
+++ b/src/log_gun.erl
@@ -3,10 +3,18 @@
 -export([filter_supervisor_reports/2]).
 
 -spec filter_supervisor_reports(logger:log_event(), any()) -> logger:filter_return().
-filter_supervisor_reports(#{msg := {report, Report}} = Event, _) ->
+filter_supervisor_reports(#{msg := {report, Report}} = Event, _) when is_list(Report) ->
+    case lists:sort(Report) of
+        [{errorContext, shutdown_error}, {offender, _}, {reason, Reason}, {supervisor, _}] when
+                Reason == noproc orelse Reason == {shutdown, normal} ->
+            stop;
+        _ ->
+            Event
+    end;
+filter_supervisor_reports(#{msg := {report, Report}} = Event, _) when is_map(Report)->
     case Report of
         #{reason := Reason, errorContext := shutdown_error} when
-                Reason == norpoc
+                Reason == noproc
                 orelse Reason == {shutdown, normal} ->
             stop;
         _ ->

--- a/src/log_gun.erl
+++ b/src/log_gun.erl
@@ -5,7 +5,7 @@
 -spec filter_supervisor_reports(logger:log_event(), any()) -> logger:filter_return().
 filter_supervisor_reports(#{msg := {report, #{report := Report}}} = Event, _) when is_list(Report) ->
     case lists:sort(Report) of
-        [{errorContext, shutdown_error}, {offender, _}, {reason, Reason}, {supervisor, {local,gun_sup}}] when
+        [{errorContext, shutdown_error}, {offender, _}, {reason, Reason}, {supervisor, {local, gun_sup}}] when
                 Reason == noproc orelse Reason == {shutdown, normal} ->
             stop;
         _ ->

--- a/src/log_gun.erl
+++ b/src/log_gun.erl
@@ -8,7 +8,9 @@ filter_supervisor_reports(#{msg := {report, Report}} = Event, _) ->
         #{reason := Reason, errorContext := shutdown_error} when
                 Reason == norpoc
                 orelse Reason == {shutdown, normal} ->
-            ignore;
+            stop;
         _ ->
             Event
-    end.
+    end;
+filter_supervisor_reports(Event, _) ->
+    Event.

--- a/src/log_gun.erl
+++ b/src/log_gun.erl
@@ -3,19 +3,10 @@
 -export([filter_supervisor_reports/2]).
 
 -spec filter_supervisor_reports(logger:log_event(), any()) -> logger:filter_return().
-filter_supervisor_reports(#{msg := {report, Report}} = Event, _) when is_list(Report) ->
+filter_supervisor_reports(#{msg := {report, #{report := Report}}} = Event, _) when is_list(Report) ->
     case lists:sort(Report) of
-        [{errorContext, shutdown_error}, {offender, _}, {reason, Reason}, {supervisor, _}] when
+        [{errorContext, shutdown_error}, {offender, _}, {reason, Reason}, {supervisor, {local,gun_sup}}] when
                 Reason == noproc orelse Reason == {shutdown, normal} ->
-            stop;
-        _ ->
-            Event
-    end;
-filter_supervisor_reports(#{msg := {report, Report}} = Event, _) when is_map(Report)->
-    case Report of
-        #{reason := Reason, errorContext := shutdown_error} when
-                Reason == noproc
-                orelse Reason == {shutdown, normal} ->
             stop;
         _ ->
             Event

--- a/src/log_gun.erl
+++ b/src/log_gun.erl
@@ -1,0 +1,14 @@
+-module(log_gun).
+
+-export([filter_supervisor_reports/2]).
+
+-spec filter_supervisor_reports(logger:log_event(), any()) -> logger:filter_return().
+filter_supervisor_reports(#{msg := {report, Report}} = Event, _) ->
+    case Report of
+        #{reason := Reason, errorContext := shutdown_error} when
+                Reason == norpoc
+                orelse Reason == {shutdown, normal} ->
+            ignore;
+        _ ->
+            Event
+    end.

--- a/src/log_yaml.erl
+++ b/src/log_yaml.erl
@@ -45,6 +45,7 @@ validator() ->
         console => bool(),
         formatter => enum([plain, json]),
         exclude_meta => list(atom()),
+        print_gun_shutdown_errors => bool(),
         dir => and_then(directory(write), string())},
       [unique, {defaults, log:defaults()}]).
 


### PR DESCRIPTION
PR adds option to disable logging of gun `noproc` and `{shutdown, normal}` error reports in `shutdown_error` context from gun supervisor.   
Such reports occur in gun 1.x.x when calling process finishes earlier than gun's connection process. This situation does not affect application therefore I implemented filters to supress these reports.
The root issue is gun's implementation of `gun:close`, proper solution is using `gun:shutdown` from gun 2.0, however there is no prod gun 2.0 release at the moment, only release candidates.