### PR TITLE
Set time offset explicitly to use local time

### DIFF
--- a/src/log_plain.erl
+++ b/src/log_plain.erl
@@ -36,6 +36,7 @@
 formatter_config() ->
     #{legacy_header => false,
       time_designator => $T,
+      time_offset => "",
       exclude_meta => log:get_env_list(exclude_meta),
       single_line => log:get_env_bool(single_line),
       max_size => log:get_env_pos_int(max_line_size, unlimited)}.


### PR DESCRIPTION
As stated in [logger_formatter man](https://www.erlang.org/doc/man/logger_formatter.html#type-config) `time_offset` parameter :
```
Defaults to an empty string, meaning that timestamps are displayed in local time.
However, for backwards compatibility, if the SASL configuration parameter [utc_log](https://www.erlang.org/doc/man/sasl_app.html#utc_log)=true,
the default is changed to "Z", meaning that timestamps are displayed in UTC.
```

This behaviour change by SASL is undesirable in case of `log` library, therefore set `time_offset` to an empty string explicitly.