### PR TITLE
Fix invalid gun filter instantiation

### DIFF
--- a/src/log.erl
+++ b/src/log.erl
@@ -392,7 +392,9 @@ get_meta() ->
 enable_gun_filters(LevelList) when is_list(LevelList) ->
     lists:foreach(fun enable_gun_filters/1, LevelList);
 enable_gun_filters(Level) ->
-    case logger:add_handler_filter(get_handler_id(Level), gun_error_filter, {fun log_gun:filter_supervisor_reports/2, #{}}) of
+    case logger:add_handler_filter(get_handler_id(Level),
+                                   gun_error_filter,
+                                   {fun log_gun:filter_supervisor_reports/2, #{}}) of
         ok -> ok;
         {error, {already_exist, _}} -> ok
     end.

--- a/src/log.erl
+++ b/src/log.erl
@@ -351,7 +351,7 @@ get_env_bool(Opt) ->
         _ -> default(Opt)
     end.
 
--spec get_env_atom(option()) -> boolean().
+-spec get_env_atom(option()) -> atom().
 get_env_atom(Opt) ->
     case application:get_env(?MODULE, Opt) of
         {ok, A} when is_atom(A) -> A;
@@ -366,7 +366,7 @@ get_formatter_from_env() ->
         _ -> default(formatter)
     end.
 
--spec get_level_from_env() -> logger:level().
+-spec get_level_from_env() -> logger:level() | none.
 get_level_from_env() ->
     case application:get_env(?MODULE, level) of
         {ok, L} when L == emergency orelse

--- a/src/log.erl
+++ b/src/log.erl
@@ -222,18 +222,15 @@ load() ->
             ok -> ok;
             {error, {not_found, _}} -> ok
         end,
-        case get_env_bool(console) andalso add_handler(console, Config) of
+        case get_env_bool(console) of
             false -> ok;
-            ok -> ok;
-            {error, {already_exist, _}} -> ok
+            true -> add_handler(console, Config)
         end
     catch _:{Tag, Err} when Tag == badmatch; Tag == case_clause ->
             ?LOG_CRITICAL("Failed to set logging: ~p", [Err]),
             Err
     end.
 
-add_handler(none, _Config) ->
-    ok;
 add_handler(Level0, Config) ->
     add_handler(Level0, Config, []).
 add_handler(Level0, Config, Filters) ->

--- a/src/log.erl
+++ b/src/log.erl
@@ -205,7 +205,7 @@ load() ->
                             [Level];
                         separate ->
                             LList = get_level_list(Level),
-                            [add_handler(FileLogLevel, Config) || FileLogLevel <- get_level_list(Level)],
+                            [add_handler(FileLogLevel, Config) || FileLogLevel <- LList],
                             LList;
                         debug_and_error ->
                             LList = [error, debug],


### PR DESCRIPTION
Previous fix was not final. Using `debug_and_error` mode with level other than debug caused a crash. 
This MR fixes that problem and also fixes CI.